### PR TITLE
Add symlink support, closes #8

### DIFF
--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -240,6 +240,28 @@ module Archive
           nil
         end
 
+        # Creates a symbolic link entry in the tar.
+        def symlink(name, link_target, opts = {})
+          raise ClosedStream if @closed
+
+          raise FileNameTooLong if link_target.size > 100
+
+          name, prefix = split_name(name)
+          header = {
+            :name => name,
+            :mode => opts[:mode],
+            :typeflag => "2",
+            :size => 0,
+            :linkname => link_target,
+            :gid => opts[:gid],
+            :uid => opts[:uid],
+            :mtime => opts[:mtime],
+            :prefix => prefix
+          }
+          @io.write(PosixHeader.new(header))
+          nil
+        end
+
         # Passes the #flush method to the wrapped stream, used for buffered
         # streams.
         def flush

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -48,13 +48,19 @@ module TarTester
     header("5", name, prefix, 0, mode, checksum)
   end
 
-  def header(type, fname, dname, length, mode, checksum = nil)
+  def tar_symlink_header(name, prefix, mode, target)
+    h = header("2", name, prefix, 0, mode, nil, target)
+    checksum = calc_checksum(h)
+    header("2", name, prefix, 0, mode, checksum, target)
+  end
+
+  def header(type, fname, dname, length, mode, checksum = nil, linkname = "")
     checksum ||= " " * 8
     arr = [ASCIIZ(fname, 100), Z(to_oct(mode, 7)), Z(to_oct(nil, 7)),
            Z(to_oct(nil, 7)), Z(to_oct(length, 11)), Z(to_oct(0, 11)),
-           checksum, type, "\0" * 100, "ustar\0", "00", ASCIIZ("", 32),
-           ASCIIZ("", 32), Z(to_oct(nil, 7)), Z(to_oct(nil, 7)),
-           ASCIIZ(dname, 155) ]
+           checksum, type, ASCIIZ(linkname, 100), "ustar\0", "00",
+           ASCIIZ("", 32), ASCIIZ("", 32), Z(to_oct(nil, 7)),
+           Z(to_oct(nil, 7)), ASCIIZ(dname, 155) ]
     arr = arr.join.bytes.to_a
     h = arr.pack("C100C8C8C8C12C12C8CC100C6C2C32C32C8C8C155")
     ret = h + "\0" * (512 - h.size)

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -62,6 +62,7 @@ class TestTarWriter < Minitest::Test
     assert_raises(Minitar::ClosedStream) { @os.flush }
     assert_raises(Minitar::ClosedStream) { @os.add_file("dfdsf", :mode => 0644) {} }
     assert_raises(Minitar::ClosedStream) { @os.mkdir "sdfdsf", :mode => 0644 }
+    assert_raises(Minitar::ClosedStream) { @os.symlink "a", "b", :mode => 0644 }
   end
 
   def test_file_name_is_split_correctly
@@ -168,5 +169,20 @@ class TestTarWriter < Minitest::Test
       end
     end
     @os.add_file_simple("lib/foo/bar", :mode => 0644, :size => 10) {|f| }
+  end
+
+  def test_symlink
+    @dummyos.reset
+    @os.symlink("lib/foo/bar", "lib/foo/baz", :mode => 0644)
+    @os.flush
+    assert_headers_equal(tar_dir_header("lib/foo", "", 0644),
+                        @dummyos.data[0, 512])
+  end
+
+  def test_symlink_target_size_is_checked
+    @dummyos.reset
+    assert_raises(Minitar::FileNameTooLong) do
+      @os.symlink("lib/foo/bar", "x" * 101)
+    end
   end
 end


### PR DESCRIPTION
This creates tar archives with working symlinks, although I am having trouble making the test for this work.  I end up with this as a failure, any pointers/help appreciated:

```
  1) Failure:
TestTarWriter#test_symlink [/nycasa.nydc.fxcorp.prv/nfs1/home/pfritchman/src/minitar/test/test_tar_writer.rb:178]:
Field name of the tar header differs..
--- expected
+++ actual
@@ -1 +1 @@
-"lib/foo\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+"lib/foo/bar\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/minitar/12)
<!-- Reviewable:end -->
