### PR TITLE
Fix an off-by-1 error in split_name

### DIFF
--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -269,7 +269,7 @@ module Archive
 
             loop do
               nxt = parts.pop || ""
-              break if newname.size + 1 + nxt.size > 100
+              break if newname.size + 1 + nxt.size >= 100
               newname = "#{nxt}/#{newname}"
             end
 

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -67,9 +67,10 @@ class TestTarWriter < Minitest::Test
   def test_file_name_is_split_correctly
       # test insane file lengths, and: a{100}/b{155}, etc
     @dummyos.reset
-    names = [ "#{'a' * 155}/#{'b' * 100}", "#{'a' * 151}/#{'qwer/' * 19}bla" ]
-    o_names = [ "#{'b' * 100}", "#{'qwer/' * 19}bla" ]
-    o_prefixes = [ "a" * 155, "a" * 151 ]
+    names = [ "#{'a' * 155}/#{'b' * 100}", "#{'a' * 151}/#{'qwer/' * 19}bla",
+              "/#{'a' * 49}/#{'b' * 50}" ]
+    o_names = [ "#{'b' * 100}", "#{'qwer/' * 19}bla", "#{'b' * 50}" ]
+    o_prefixes = [ "a" * 155, "a" * 151, "/#{'a' * 49}" ]
     names.each do |name|
       @os.add_file_simple(name, :mode => 0644, :size => 10) { }
     end


### PR DESCRIPTION
In the case of a 101-character name starting with '/', the leading '/'
would get stripped in split_name (e.g. adding `/#{'a'*100}` just ended
up in the archive as `#{'a'*100}`).
