### PR TITLE
Don't use /win32/ to detect Windows

### DIFF
--- a/lib/archive/tar/minitar.rb
+++ b/lib/archive/tar/minitar.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 require 'fileutils'
+require 'rbconfig'
 
 module Archive #:nodoc:
   module Tar #:nodoc:
@@ -83,6 +84,10 @@ module Archive #:nodoc:
       UnexpectedEOF = Class.new(StandardError)
 
       class << self
+        def windows?
+          RbConfig::CONFIG["host_os"] =~ /^(mswin|mingw|cygwin)/
+        end
+
         # Tests if +path+ refers to a directory. Fixes an apparently
         # corrupted <tt>stat()</tt> call on Windows.
         def dir?(path)
@@ -160,7 +165,7 @@ module Archive #:nodoc:
           stats[:mtime]  ||= stat.mtime
           stats[:size]   = stat.size
 
-          if RUBY_PLATFORM =~ /win32/
+          if windows?
             stats[:uid]  = nil
             stats[:gid]  = nil
           else

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,6 +1,7 @@
 # -*- ruby encoding: utf-8 -*-
 
 require 'fileutils'
+require 'minitar'
 
 gem 'minitest'
 require 'minitest/autorun'
@@ -28,7 +29,7 @@ module TarTester
   end
 
   def assert_modes_equal(expected, actual, name)
-    unless RUBY_PLATFORM =~ /win32/
+    unless Minitar.windows?
       expected = "%04o" % (expected & 0777)
       actual = "%04o" % (actual & 0777)
 

--- a/test/test_tar_input.rb
+++ b/test/test_tar_input.rb
@@ -95,10 +95,8 @@ UTAKRsEoGAWjYBSMglEwCkbBKBgFo2AUjIJRMApGwSgYBaNgFIwCUgAAGnyo6wAoAAA=
           assert_equal(TEST_CONTENTS[entry.name][:size], File.stat(name).size)
         end
 
-        unless RUBY_PLATFORM =~ /win32/
-          assert_modes_equal(TEST_CONTENTS[entry.name][:mode],
-                             File.stat(name).mode, entry.name)
-        end
+        assert_modes_equal(TEST_CONTENTS[entry.name][:mode],
+                           File.stat(name).mode, entry.name)
 
         if i.zero?
           begin


### PR DESCRIPTION
Apparently the regexp is not enough to detect Windows.
