### PR TITLE
Off by one split

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -76,6 +76,7 @@ Thanks to everyone who has contributed to minitar:
 *   Matthew Kent
 *   Michal Suchanek
 *   Mike Furr
+*   Pete Fritchman
 *   Zach Dennis
 
 [Minitest]: https://github.com/seattlerb/minitest

--- a/History.md
+++ b/History.md
@@ -69,6 +69,8 @@
         originally provided by Curtis Sampson.
     *   Fix [#6][] by making it raise the correct error for a long filename
         with no path components.
+    *   Fix [#13][] provided by @fetep fixes an off-by-one error on filename
+        splitting.
     *   Fix [#14][] provided by @kzys should fix Windows detection issues.
     *   Fix [#16][] as specified above.
     *   Fix an issue where Minitar.pack would not include Unix hidden files
@@ -98,5 +100,6 @@
 [#3]: https://github.com/halostatue/minitar/issues/3
 [#4]: https://github.com/halostatue/minitar/issues/4
 [#6]: https://github.com/halostatue/minitar/issues/6
+[#13]: https://github.com/halostatue/minitar/issues/13
 [#14]: https://github.com/halostatue/minitar/issues/14
 [#16]: https://github.com/halostatue/minitar/issues/16

--- a/History.md
+++ b/History.md
@@ -55,7 +55,7 @@
         Writer#add_file_simple in this case.
     *   Methods that require blocks are no longer required, so the
         Archive::Tar::Minitar::BlockRequired exception has been removed with a
-        warning.
+        warning (this may not work on Ruby 1.8).
     *   Dramatically reduced the number of strings created when creating a
         POSIX tarball header.
     *   Added a helper, Input.each_entry that iterates over each entry in an

--- a/History.md
+++ b/History.md
@@ -58,6 +58,8 @@
         warning.
     *   Dramatically reduced the number of strings created when creating a
         POSIX tarball header.
+    *   Added a helper, Input.each_entry that iterates over each entry in an
+        opened entry object.
 
 *   Bugs:
 

--- a/lib/archive/tar/minitar/input.rb
+++ b/lib/archive/tar/minitar/input.rb
@@ -30,6 +30,29 @@ module Archive::Tar::Minitar
       res
     end
 
+    # Iterates over each entry in the provided input. This wraps the common
+    # pattern of:
+    #
+    #     Archive::Tar::Minitar::Input.open(io) do |i|
+    #       inp.each do |entry|
+    #         # ...
+    #       end
+    #     end
+    #
+    # call-seq:
+    #    Archive::Tar::Minitar::Input.each_entry(io) { |input| block } -> obj
+    def self.each_entry(input)
+      stream = new(input)
+
+      begin
+        res = stream.each { |entry| yield entry }
+      ensure
+        stream.close
+      end
+
+      res
+    end
+
     # Creates a new Input object. If +input+ is a stream object that responds
     # to #read, then it will simply be wrapped. Otherwise, one will be created
     # and opened using Kernel#open. When Input#close is called, the stream

--- a/lib/archive/tar/minitar/output.rb
+++ b/lib/archive/tar/minitar/output.rb
@@ -20,14 +20,24 @@ module Archive::Tar::Minitar
     def self.open(output)
       stream = new(output)
       return stream unless block_given?
+      yield stream
+    ensure
+      stream.close
+    end
 
-      begin
-        res = yield stream
-      ensure
-        stream.close
+    # Output.tar is a wrapper for Output.open that yields the owned tar object
+    # instead of the Output object. If a block is not provided, an enumerator
+    # will be created with the same behaviour.
+    #
+    # call-seq:
+    #    Archive::Tar::Minitar::Output.tar(io) -> enumerator
+    #    Archive::Tar::Minitar::Output.tar(io) { |tar| block } -> obj
+    def self.tar(output)
+      return to_enum(__method__, output) unless block_given?
+
+      open(output) do |stream|
+        yield stream.tar
       end
-
-      res
     end
 
     # Creates a new Output object. If +output+ is a stream object that responds

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -83,16 +83,10 @@ module Archive::Tar::Minitar
     #    end
     def self.open(io) # :yields Writer:
       writer = new(io)
-
       return writer unless block_given?
-
-      begin
-        res = yield writer
-      ensure
-        writer.close
-      end
-
-      res
+      yield writer
+    ensure
+      writer.close
     end
 
     # Creates and returns a new Writer object.

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -286,7 +286,7 @@ module Archive::Tar::Minitar
 
         loop do
           nxt = parts.pop || ''
-          break if newname.size + 1 + nxt.size > 100
+          break if newname.size + 1 + nxt.size >= 100
           newname = "#{nxt}/#{newname}"
         end
 

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -67,15 +67,35 @@ class TestTarWriter < Minitest::Test
   def test_file_name_is_split_correctly
     # test insane file lengths, and: a{100}/b{155}, etc
     @dummyos.reset
-    names = [ "#{'a' * 155}/#{'b' * 100}", "#{'a' * 151}/#{'qwer/' * 19}bla" ]
-    o_names = [ 'b' * 100, "#{'qwer/' * 19}bla" ]
-    o_prefixes = [ 'a' * 155, 'a' * 151 ]
+    names = [
+      "#{'a' * 155}/#{'b' * 100}",
+      "#{'a' * 151}/#{'qwer/' * 19}bla",
+      "/#{'a' * 49}/#{'b' * 50}",
+      "#{'a' * 49}/#{'b' * 50}x",
+      "#{'a' * 49}x/#{'b' * 50}"
+    ]
+    o_names = [
+      'b' * 100,
+      "#{'qwer/' * 19}bla",
+      'b' * 50,
+      "#{'b' * 50}x",
+      'b' * 50
+    ]
+    o_prefixes = [
+      'a' * 155,
+      'a' * 151,
+      "/#{'a' * 49}",
+      'a' * 49,
+      "#{'a' * 49}x"
+    ]
     names.each do |name|
       @os.add_file_simple(name, :mode => 0o644, :size => 10) {}
     end
-    o_names.each_with_index do |nam, i|
-      assert_headers_equal(tar_file_header(nam, o_prefixes[i], 0o644, 10),
-        @dummyos.data[2 * i * 512, 512])
+    names.each_index do |i|
+      assert_headers_equal(
+        tar_file_header(o_names[i], o_prefixes[i], 0o644, 10),
+        @dummyos.data[2 * i * 512, 512]
+      )
     end
     assert_raises(Minitar::FileNameTooLong) do
       @os.add_file_simple(File.join('a' * 152, 'b' * 10, 'a' * 92),


### PR DESCRIPTION
Fix an off-by-one split (originally from #13) plus add a couple of convenience methods and make enumerator creation code more robust.