### PR TITLE
0.6.1: Restore exception blocks for great justice

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+## 0.6.1 / 2017-02-07
+
+*   Fixed issue [#24][] where streams were being improperly closed immediately
+    on open unless there was a block provided.
+
+*   Hopefully fixes issue [#23][] by releasing archive-tar-minitar after
+    minitar-cli is available.
+
 ## 0.6 / 2017-02-07
 
 *   Breaking Changes:
@@ -105,3 +113,5 @@
 [#13]: https://github.com/halostatue/minitar/issues/13
 [#14]: https://github.com/halostatue/minitar/issues/14
 [#16]: https://github.com/halostatue/minitar/issues/16
+[#23]: https://github.com/halostatue/minitar/issues/23
+[#24]: https://github.com/halostatue/minitar/issues/24

--- a/archive-tar-minitar.gemspec
+++ b/archive-tar-minitar.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: archive-tar-minitar 0.6 ruby lib
+# stub: archive-tar-minitar 0.6.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "archive-tar-minitar"
-  s.version = "0.6"
+  s.version = "0.6.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2017-02-07"
+  s.date = "2017-02-08"
   s.description = "'archive-tar-minitar' has been deprecated; just install 'minitar'. The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.6, providing a number of bug fixes including a directory\ntraversal vulnerability, CVE-2016-10173. This release starts the migration and\nmodernization of the code:\n\n*   the licence has been changed to match the modern Ruby licensing scheme\n    (Ruby and Simplified BSD instead of Ruby and GNU GPL);\n*   the +minitar+ command-line program has been separated into the\n    +minitar-cli+ gem; and\n*   the +archive-tar-minitar+ gem now points to the +minitar+ and +minitar-cli+\n    gems and discourages its installation.\n\nSome of these changes may break existing programs that depend on the internal\nstructure of the minitar library, but every effort has been made to ensure\ncompatibility; inasmuch as is possible, this compatibility will be maintained\nthrough the release of minitar 1.0 (which will have strong breaking changes).\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u{e1}ndez Pradier for the rpa-base\nproject."
   s.email = ["halostatue@gmail.com"]
   s.files = ["lib/archive-tar-minitar.rb"]

--- a/lib/archive/tar/minitar.rb
+++ b/lib/archive/tar/minitar.rb
@@ -73,7 +73,7 @@ end
 #       tar.close
 #     end
 module Archive::Tar::Minitar
-  VERSION = '0.6'.freeze # :nodoc:
+  VERSION = '0.6.1'.freeze # :nodoc:
 
   # The base class for any minitar error.
   Error = Class.new(::StandardError)

--- a/lib/archive/tar/minitar/input.rb
+++ b/lib/archive/tar/minitar/input.rb
@@ -20,9 +20,14 @@ module Archive::Tar::Minitar
     def self.open(input)
       stream = new(input)
       return stream unless block_given?
-      yield stream
-    ensure
-      stream.close
+
+      # This exception context must remain, otherwise the stream closes on open
+      # even if a block is not given.
+      begin
+        yield stream
+      ensure
+        stream.close
+      end
     end
 
     # Iterates over each entry in the provided input. This wraps the common
@@ -186,6 +191,11 @@ module Archive::Tar::Minitar
 
         yield :file_done, full_name, stats if block_given?
       end
+    end
+
+    # Returns false if the wrapped data stream is open.
+    def closed?
+      @io.closed?
     end
 
     # Returns the Reader object for direct access.

--- a/lib/archive/tar/minitar/output.rb
+++ b/lib/archive/tar/minitar/output.rb
@@ -20,9 +20,14 @@ module Archive::Tar::Minitar
     def self.open(output)
       stream = new(output)
       return stream unless block_given?
-      yield stream
-    ensure
-      stream.close
+
+      # This exception context must remain, otherwise the stream closes on open
+      # even if a block is not given.
+      begin
+        yield stream
+      ensure
+        stream.close
+      end
     end
 
     # Output.tar is a wrapper for Output.open that yields the owned tar object
@@ -59,6 +64,11 @@ module Archive::Tar::Minitar
 
     # Returns the Writer object for direct access.
     attr_reader :tar
+
+    # Returns false if the wrapped data stream is open.
+    def closed?
+      @io.closed?
+    end
 
     # Closes the Writer object and the wrapped data stream.
     def close

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -84,9 +84,14 @@ module Archive::Tar::Minitar
     def self.open(io) # :yields Writer:
       writer = new(io)
       return writer unless block_given?
-      yield writer
-    ensure
-      writer.close
+
+      # This exception context must remain, otherwise the stream closes on open
+      # even if a block is not given.
+      begin
+        yield writer
+      ensure
+        writer.close
+      end
     end
 
     # Creates and returns a new Writer object.
@@ -253,6 +258,11 @@ module Archive::Tar::Minitar
     def flush
       raise ClosedStream if @closed
       @io.flush if @io.respond_to?(:flush)
+    end
+
+    # Returns false if the writer is open.
+    def closed?
+      @closed
     end
 
     # Closes the Writer. This does not close the underlying wrapped output

--- a/minitar.gemspec
+++ b/minitar.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: minitar 0.6 ruby lib
+# stub: minitar 0.6.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "minitar"
-  s.version = "0.6"
+  s.version = "0.6.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2017-02-07"
+  s.date = "2017-02-08"
   s.description = "The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.6, providing a number of bug fixes including a directory\ntraversal vulnerability, CVE-2016-10173. This release starts the migration and\nmodernization of the code:\n\n*   the licence has been changed to match the modern Ruby licensing scheme\n    (Ruby and Simplified BSD instead of Ruby and GNU GPL);\n*   the +minitar+ command-line program has been separated into the\n    +minitar-cli+ gem; and\n*   the +archive-tar-minitar+ gem now points to the +minitar+ and +minitar-cli+\n    gems and discourages its installation.\n\nSome of these changes may break existing programs that depend on the internal\nstructure of the minitar library, but every effort has been made to ensure\ncompatibility; inasmuch as is possible, this compatibility will be maintained\nthrough the release of minitar 1.0 (which will have strong breaking changes).\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u{e1}ndez Pradier for the rpa-base\nproject."
   s.email = ["halostatue@gmail.com"]
   s.extra_rdoc_files = ["Code-of-Conduct.md", "Contributing.md", "History.md", "Licence.md", "Manifest.txt", "README.rdoc", "docs/bsdl.txt", "docs/ruby.txt"]
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<minitest>, ["~> 5.9"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.10"])
       s.add_development_dependency(%q<hoe-doofus>, ["~> 1.0"])
       s.add_development_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
       s.add_development_dependency(%q<hoe-git>, ["~> 1.6"])
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rdoc>, [">= 0.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.16"])
     else
-      s.add_dependency(%q<minitest>, ["~> 5.9"])
+      s.add_dependency(%q<minitest>, ["~> 5.10"])
       s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
       s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
       s.add_dependency(%q<hoe-git>, ["~> 1.6"])
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.16"])
     end
   else
-    s.add_dependency(%q<minitest>, ["~> 5.9"])
+    s.add_dependency(%q<minitest>, ["~> 5.10"])
     s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
     s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
     s.add_dependency(%q<hoe-git>, ["~> 1.6"])

--- a/support/hoe/deprecated_gem.rb
+++ b/support/hoe/deprecated_gem.rb
@@ -15,7 +15,10 @@ module Hoe::Deprecated_Gem # rubocop:disable Style/ClassAndModuleCamelCase
     atm.extra_rdoc_files.clear
     atm.rdoc_options.clear
     atm.dependencies.clear
-    atm.add_dependency(spec.name, "~> #{spec.version}")
+
+    version = Gem::Version.new(spec.version.segments.first(2).join('.'))
+
+    atm.add_dependency(spec.name, "~> #{version}")
     atm.add_dependency(%Q(#{spec.name}-cli), '~> 0.6')
 
     unless @include_all

--- a/test/test_tar_input.rb
+++ b/test/test_tar_input.rb
@@ -38,6 +38,15 @@ UTAKRsEoGAWjYBSMglEwCkbBKBgFo2AUjIJRMApGwSgYBaNgFIwCUgAAGnyo6wAoAAA=
     FileUtils.rm_rf('data__')
   end
 
+  def test_open_no_block
+    reader = Zlib::GzipReader.new(StringIO.new(TEST_TGZ))
+    input = Minitar::Input.open(reader)
+    refute input.closed?
+  ensure
+    input.close
+    assert input.closed?
+  end
+
   def test_each_works
     reader = Zlib::GzipReader.new(StringIO.new(TEST_TGZ))
     Minitar::Input.open(reader) do |stream|

--- a/test/test_tar_output.rb
+++ b/test/test_tar_output.rb
@@ -19,6 +19,14 @@ class TestTarOutput < Minitest::Test
     FileUtils.rm_rf('data__')
   end
 
+  def test_open_no_block
+    output = Minitar::Output.open(@tarfile)
+    refute output.closed?
+  ensure
+    output.close
+    assert output.closed?
+  end
+
   def test_file_looks_good
     Minitar::Output.open(@tarfile) do |os|
       Dir.chdir('data__') do

--- a/test/test_tar_reader.rb
+++ b/test/test_tar_reader.rb
@@ -4,6 +4,19 @@ require 'minitar'
 require 'minitest_helper'
 
 class TestTarReader < Minitest::Test
+  def test_open_no_block
+    str = tar_file_header('lib/foo', '', 0o10644, 10) + "\0" * 512
+    str += tar_file_header('bar', 'baz', 0o644, 0)
+    str += tar_dir_header('foo', 'bar', 0o12345)
+    str += "\0" * 1024
+
+    reader = Minitar::Reader.open(StringIO.new(str))
+    refute reader.closed?
+  ensure
+    reader.close
+    refute reader.closed? # Reader doesn't actually close anything
+  end
+
   def test_multiple_entries
     str = tar_file_header('lib/foo', '', 0o10644, 10) + "\0" * 512
     str += tar_file_header('bar', 'baz', 0o644, 0)

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -31,6 +31,15 @@ class TestTarWriter < Minitest::Test
     @os.close
   end
 
+  def test_open_no_block
+    writer = Minitar::Writer.open(@dummyos)
+    refute writer.closed?
+  ensure
+    writer.close
+    assert writer.closed?
+  end
+
+
   def test_add_file_simple
     @dummyos.reset
 


### PR DESCRIPTION
- Fixes #23 (hopefully) by being released in the proper order.
- Fixes #24 by restoring exception blocks that were improperly removed.