### PR TITLE
Support long file names w/ GNU's extension

### DIFF
--- a/lib/archive/tar/minitar/posix_header.rb
+++ b/lib/archive/tar/minitar/posix_header.rb
@@ -37,6 +37,8 @@ module Archive::Tar::Minitar; end
 class Archive::Tar::Minitar::PosixHeader
   BLOCK_SIZE = 512
 
+  GNU_EXT_LONG_LINK = '././@LongLink'
+
   # Fields that must be set in a POSIX tar(1) header.
   REQUIRED_FIELDS = [ :name, :size, :prefix, :mode ].freeze
   # Fields that may be set in a POSIX tar(1) header.
@@ -146,7 +148,7 @@ class Archive::Tar::Minitar::PosixHeader
   # Returns +true+ if the header is a long name special header which indicates
   # that the next block of data is the filename.
   def long_name?
-    typeflag == 'L' && name == '././@LongLink'
+    typeflag == 'L' && name == GNU_EXT_LONG_LINK
   end
 
   # A string representation of the header.

--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -5,6 +5,7 @@ module Archive::Tar::Minitar
   # stream may be sequential or random access, but certain features only work
   # with random access data streams.
   class Reader
+    include Enumerable
     # This marks the EntryStream closed for reading without closing the
     # actual data stream.
     module InvalidEntryStream

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -106,21 +106,24 @@ class TestTarWriter < Minitest::Test
         @dummyos.data[2 * i * 512, 512]
       )
     end
-    assert_raises(Minitar::FileNameTooLong) do
-      @os.add_file_simple(File.join('a' * 152, 'b' * 10, 'a' * 92),
-        :mode => 0o644, :size => 10) {}
-    end
-    assert_raises(Minitar::FileNameTooLong) do
-      @os.add_file_simple(File.join('a' * 162, 'b' * 10),
-        :mode => 0o644, :size => 10) {}
-    end
-    assert_raises(Minitar::FileNameTooLong) do
-      @os.add_file_simple(File.join('a' * 10, 'b' * 110),
-        :mode => 0o644, :size => 10) {}
-    end
+  end
+
+  def test_file_name_is_long
+    @dummyos.reset
+
+    @os.add_file_simple(File.join('a' * 152, 'b' * 10, 'c' * 92),
+                        :mode => 0o644, :size => 10) {}
+    @os.add_file_simple(File.join('d' * 162, 'e' * 10),
+                        :mode => 0o644, :size => 10) {}
+    @os.add_file_simple(File.join('f' * 10, 'g' * 110),
+                        :mode => 0o644, :size => 10) {}
     # Issue #6.
-    assert_raises(Minitar::FileNameTooLong) do
-      @os.add_file_simple('a' * 114, :mode => 0o644, :size => 10) {}
+    @os.add_file_simple('a' * 114, :mode => 0o644, :size => 10) {}
+
+    # "././@LongLink", a file name, its actual header, its data, ...
+    4.times do |i|
+      assert_equal(Minitar::PosixHeader::GNU_EXT_LONG_LINK,
+                   @dummyos.data[4 * i * 512, 32].rstrip)
     end
   end
 


### PR DESCRIPTION
GNU's `LongName` and POSIX.1-2001's extended tar format are
not supported so far.