### PR TITLE
Provide Security Details for Minitar

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -78,6 +78,7 @@ Thanks to everyone who has contributed to minitar:
 *   Mike Furr
 *   Pete Fritchman
 *   Zach Dennis
+*   ooooooo\_q
 
 [Minitest]: https://github.com/seattlerb/minitest
 [quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+## NEXT / 2018-02-19
+
+*   Fixed issue [#28][] with a modified version of PR [#29][] covering the
+    security policy and position for Minitar. Thanks so much to ooooooo\_q for
+    the report and an initial patch.
+
 ## 0.6.1 / 2017-02-07
 
 *   Fixed issue [#24][] where streams were being improperly closed immediately
@@ -115,3 +121,5 @@
 [#16]: https://github.com/halostatue/minitar/issues/16
 [#23]: https://github.com/halostatue/minitar/issues/23
 [#24]: https://github.com/halostatue/minitar/issues/24
+[#28]: https://github.com/halostatue/minitar/issues/28
+[#29]: https://github.com/halostatue/minitar/issues/29

--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,12 @@ wrapped data stream object.
     tar.close
   end
 
+== Security
+
+Kernel.open is used for Minitar::Output and Minitar::Input.
+Ruby's Kernel.open has multiple behaviors.(ex command injection.)
+Refer: https://sakurity.com/blog/2015/02/28/openuri.html
+
 == minitar Semantic Versioning
 
 The minitar library uses a {Semantic Versioning}[http://semver.org/] scheme

--- a/README.rdoc
+++ b/README.rdoc
@@ -73,11 +73,33 @@ wrapped data stream object.
     tar.close
   end
 
-== Security
+== Minitar and Security
 
-Kernel.open is used for Minitar::Output and Minitar::Input.
-Ruby's Kernel.open has multiple behaviors.(ex command injection.)
-Refer: https://sakurity.com/blog/2015/02/28/openuri.html
+Minitar aims to be secure by default for the data *inside* of a tarfile. If
+there are any security issues discovered, please feel free to open an issue.
+Should you wish to make a more confidential report, you can find my PGP key
+information at {Keybase}[https://keybase.io/halostatue]. Bear with me: I do not
+use PGP regularly, so it may take some time to remember the command invocations
+required to successfully handle this.
+
+Minitar does *not* perform validation of path names provided to the convenience
+calsses Minitar::Output and Minitar::Input, which use Kernel.open for their
+underlying implementations when not given an IO-like object.
+
+Improper use of these classes with arbitrary input filenames may leave your
+your software to the same class of vulnerability as reported for Net::FTP
+({CVE-2017-17405}[https://nvd.nist.gov/vuln/detail/CVE-2017-17405]). Of
+particular note, "if the localfile argument starts with the '|' pipe character,
+the command following the pipe character is executed."
+
+Additionally, the use of the `open-uri` library (which extends Kernel.open with
+transparent implementations of Net::HTTP, Net::HTTPS, and Net::FTP), there are
+other possible vulnerabilities when accepting arbitrary input, as
+{detailed}[https://sakurity.com/blog/2015/02/28/openuri.html] by Egor Homakov.
+
+These security vulnerabilities may be avoided, even with the Minitar::Output
+and Minitar::Input convenience classes, by providing IO-like objects instead of
+pathname-like objects as the source or destination of these classes.
 
 == minitar Semantic Versioning
 


### PR DESCRIPTION
a9f3638 (Austin Ziegler, 3 minutes ago)
    Expand on the initial comments on security

    - Make the overall security stance clear (we provide security against what
    is
     within the tarfile; it is necessary for consumers to provide their own
     security in referencing the tarfile proper).

    - Provide information on secure contact information.

 429d75e (ooooooo_q, 32 hours ago)
    update readme (#28)