### PR TITLE
Fix data size

### DIFF
--- a/lib/archive/tar/minitar/posix_header.rb
+++ b/lib/archive/tar/minitar/posix_header.rb
@@ -181,7 +181,7 @@ class Archive::Tar::Minitar::PosixHeader
            oct(mtime, 11), chksum, ' ', typeflag, linkname, magic, version,
            uname, gname, oct(devmajor, 7), oct(devminor, 7), prefix]
     str = arr.pack(HEADER_PACK_FORMAT)
-    str + "\0" * ((BLOCK_SIZE - str.size) % BLOCK_SIZE)
+    str + "\0" * ((BLOCK_SIZE - str.bytesize) % BLOCK_SIZE)
   end
 
   ##

--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -58,7 +58,7 @@ module Archive::Tar::Minitar
         len ||= @size - @read
         max_read = [len, @size - @read].min
         ret = @io.read(max_read)
-        @read += ret.size
+        @read += ret.bytesize
         ret
       end
 
@@ -229,7 +229,7 @@ module Archive::Tar::Minitar
         else
           pending = size - entry.bytes_read
           while pending > 0
-            bread = @io.read([pending, 4096].min).size
+            bread = @io.read([pending, 4096].min).bytesize
             raise UnexpectedEOF if @io.eof?
             pending -= bread
           end

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -156,23 +156,23 @@ module Archive::Tar::Minitar
       else
         raise ArgumentError, 'No data provided' unless data
 
-        size = data.size if size < data.size
+        size = data.size if size.nil? || size < data.size
       end
 
       header[:size] = size
 
       @io.write(PosixHeader.new(header))
 
-      os = BoundedWriteStream.new(@io, opts[:size])
+      os = BoundedWriteStream.new(@io, size)
       if block_given?
         yield os
       else
         os.write(data)
       end
 
-      min_padding = opts[:size] - os.written
+      min_padding = size - os.written
       @io.write("\0" * min_padding)
-      remainder = (512 - (opts[:size] % 512)) % 512
+      remainder = (512 - (size % 512)) % 512
       @io.write("\0" * remainder)
     end
 

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -48,10 +48,10 @@ module Archive::Tar::Minitar
       end
 
       def write(data)
-        raise WriteBoundaryOverflow if (data.size + @written) > @limit
+        raise WriteBoundaryOverflow if (data.bytesize + @written) > @limit
         @io.write(data)
-        @written += data.size
-        data.size
+        @written += data.bytesize
+        data.bytesize
       end
     end
 
@@ -156,7 +156,7 @@ module Archive::Tar::Minitar
       else
         raise ArgumentError, 'No data provided' unless data
 
-        size = data.size if size.nil? || size < data.size
+        size = data.bytesize if size.nil? || size < data.bytesize
       end
 
       header[:size] = size
@@ -278,9 +278,9 @@ module Archive::Tar::Minitar
     def split_name(name)
       # TODO: Enable long-filename write support.
 
-      raise FileNameTooLong if name.size > 256
+      raise FileNameTooLong if name.bytesize > 256
 
-      if name.size <= 100
+      if name.bytesize <= 100
         prefix = ''
       else
         parts = name.split(/\//)
@@ -290,7 +290,7 @@ module Archive::Tar::Minitar
 
         loop do
           nxt = parts.pop || ''
-          break if newname.size + 1 + nxt.size >= 100
+          break if newname.bytesize + 1 + nxt.bytesize >= 100
           newname = "#{nxt}/#{newname}"
         end
 
@@ -298,7 +298,7 @@ module Archive::Tar::Minitar
 
         name = newname
 
-        raise FileNameTooLong if name.size > 100 || prefix.size > 155
+        raise FileNameTooLong if name.bytesize > 100 || prefix.bytesize > 155
       end
 
       [ name, prefix ]


### PR DESCRIPTION
Sorry for collect two fixes to one pull request, because the conflict.

One is fix for should be use `String#bytesize` instead of `String#size`.

When packing the file included multibyte character, tar file is broken.

Another is fix for to be omissible `size` parameter with `Minitar::Writer#add_file_simple`.

Thanks.
