### PR TITLE
Fix for occur error by .pos method

### DIFF
--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -179,7 +179,7 @@ module Archive::Tar::Minitar
     # Creates and returns a new Reader object.
     def initialize(io)
       @io = io
-      @init_pos = (io.pos rescue nil)
+      @init_pos = io.pos rescue nil
     end
 
     # Resets the read pointer to the beginning of data stream. Do not call

--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -179,7 +179,7 @@ module Archive::Tar::Minitar
     # Creates and returns a new Reader object.
     def initialize(io)
       @io = io
-      @init_pos = io.pos
+      @init_pos = (io.pos rescue nil)
     end
 
     # Resets the read pointer to the beginning of data stream. Do not call


### PR DESCRIPTION
Fix for posible stdin or IO liked object without `.pos` method by `Minitar::Reader.new`.

Thanks.
