### PR TITLE
Treat a regular file entry with a name ending with a slash as a directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ mime_version =
     gem 'rake', '~> 10.0'
     '1.25'
   elsif RUBY_VERSION < '2.0'
+    gem 'rdoc', '< 6.0'
     '2.0'
   elsif RUBY_VERSION >= '2.0'
     if RUBY_ENGINE == 'ruby'

--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -74,13 +74,24 @@ module Archive::Tar::Minitar
 
       # Returns +true+ if the entry represents a directory.
       def directory?
-        @typeflag == '5'
+        case @typeflag
+        when '5'
+          true
+        when '0', "\0"
+          # If the name ends with a slash, treat it as a directory.
+          # This is what other major tar implementations do for
+          # interoperability and compatibility with older tar variants
+          # and some new ones.
+          @name.end_with?('/')
+        else
+          false
+        end
       end
       alias directory directory?
 
       # Returns +true+ if the entry represents a plain file.
       def file?
-        @typeflag == '0' || @typeflag == "\0"
+        (@typeflag == '0' || @typeflag == "\0") && !@name.end_with?('/')
       end
       alias file file?
 

--- a/test/test_tar_reader.rb
+++ b/test/test_tar_reader.rb
@@ -21,13 +21,14 @@ class TestTarReader < Minitest::Test
     str = tar_file_header('lib/foo', '', 0o10644, 10) + "\0" * 512
     str += tar_file_header('bar', 'baz', 0o644, 0)
     str += tar_dir_header('foo', 'bar', 0o12345)
+    str += tar_file_header('src/', '', 0o755, 0) # "file" with a trailing slash
     str += "\0" * 1024
-    names = %w(lib/foo bar foo)
-    prefixes = ['', 'baz', 'bar']
-    modes = [0o10644, 0o644, 0o12345]
-    sizes = [10, 0, 0]
-    isdir = [false, false, true]
-    isfile = [true, true, false]
+    names = %w(lib/foo bar foo src/)
+    prefixes = ['', 'baz', 'bar', '']
+    modes = [0o10644, 0o644, 0o12345, 0o755]
+    sizes = [10, 0, 0, 0]
+    isdir = [false, false, true, true]
+    isfile = [true, true, false, false]
     Minitar::Reader.new(StringIO.new(str)) do |is|
       i = 0
       is.each_entry do |entry|


### PR DESCRIPTION
This is what other major tar implementations do for interoperability and compatibility with older tar variants and some new ones.

- GNU tar: http://git.savannah.gnu.org/cgit/tar.git/tree/src/extract.c?id=3c2a2cd94d3b062aa5bf850b82364039ec9c6029#n1543
- libarchive: https://github.com/libarchive/libarchive/blob/f5e11acaa8779738ce166b266d1cd3ad1e666a37/libarchive/archive_read_support_format_tar.c#L566-L583

Related issue with a link to an example tar file: https://bugs.ruby-lang.org/issues/15461