### PR TITLE
make fsync skippable optionally

### DIFF
--- a/lib/archive/tar/minitar.rb
+++ b/lib/archive/tar/minitar.rb
@@ -245,7 +245,7 @@ module Archive::Tar::Minitar
     # A convenience method to unpack files from +src+ into the directory
     # specified by +dest+. Only those files named explicitly in +files+
     # will be extracted.
-    def unpack(src, dest, files = [], &block)
+    def unpack(src, dest, files = [], options = [], &block)
       Input.open(src) do |inp|
         if File.exist?(dest) and !dir?(dest)
           raise %q(Can't unpack to a non-directory.)
@@ -255,7 +255,7 @@ module Archive::Tar::Minitar
 
         inp.each do |entry|
           if files.empty? or files.include?(entry.full_name)
-            inp.extract_entry(dest, entry, &block)
+            inp.extract_entry(dest, entry, options, &block)
           end
         end
       end

--- a/test/test_tar_input.rb
+++ b/test/test_tar_input.rb
@@ -216,4 +216,12 @@ UTAKRsEoGAWjYBSMglFACgAAuUHUvwAoAAA=
     reader = Zlib::GzipReader.new(StringIO.new(OCTAL_WRAPPED_BY_SPACE_TGZ))
     Minitar.unpack(reader, 'data__', [])
   end
+
+  def test_fsync_false
+    outer = 0
+    Minitar.unpack(Zlib::GzipReader.new(StringIO.new(TEST_TGZ)), 'data__', [], options = [:fsync => false]) do |label, path, stats| 
+      outer += 1
+      end
+    assert_equal(6, outer)
+  end
 end


### PR DESCRIPTION
for projects using minitar (like Puppet) that have their own fsync fail-safes (we extract into a temp directory, then only rename to extracted directory after the extraction is complete), this adds an option to set fsync to `false`, increasing performance/speed for extractions.