### PR TITLE
Fix Minitar::Writer#add_file with longname

### DIFF
--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -211,12 +211,15 @@ module Archive::Tar::Minitar
         raise Archive::Tar::Minitar::NonSeekableStream
       end
 
+      _, _, needs_long_name = split_name(name)
+
+      data_offset = needs_long_name ? 3 * 512 : 512
       init_pos = @io.pos
-      @io.write("\0" * 512) # placeholder for the header
+      @io.write("\0" * data_offset) # placeholder for the header
 
       yield WriteOnlyStream.new(@io), opts
 
-      size      = @io.pos - (init_pos + 512)
+      size      = @io.pos - (init_pos + data_offset)
       remainder = (512 - (size % 512)) % 512
       @io.write("\0" * remainder)
 

--- a/support/hoe/deprecated_gem.rb
+++ b/support/hoe/deprecated_gem.rb
@@ -4,7 +4,15 @@
 # plugin loading.)
 module Hoe::Deprecated_Gem # rubocop:disable Style/ClassAndModuleCamelCase
   def linked_spec(spec)
-    atm = YAML.load(YAML.dump(spec))
+    permitted_classes = [
+      Gem::Specification, Gem::Version, Gem::Requirement, Time
+    ]
+    atm = if RUBY_VERSION >= '2.6'
+            YAML.safe_load(YAML.dump(spec),
+                           permitted_classes: permitted_classes)
+          else
+            YAML.safe_load(YAML.dump(spec), permitted_classes)
+          end
     atm.name = 'archive-tar-minitar'
     d = %Q('#{atm.name}' has been deprecated; just install '#{spec.name}'.)
     atm.description = "#{d} #{spec.description}"

--- a/support/hoe/deprecated_gem.rb
+++ b/support/hoe/deprecated_gem.rb
@@ -1,17 +1,25 @@
-
 # A Hoe plug-in to provide a second, linked gemspec, for a gem that has been
 # deprecated in favour of a modern name. (The name is an artifact of Hoe's
 # plugin loading.)
 module Hoe::Deprecated_Gem # rubocop:disable Style/ClassAndModuleCamelCase
   def linked_spec(spec)
-    permitted_classes = [
-      Gem::Specification, Gem::Version, Gem::Requirement, Time
+    permitted_classes = %w[
+      Symbol Time Date Gem::Dependency Gem::Platform Gem::Requirement
+      Gem::Specification Gem::Version Gem::Version::Requirement
+      YAML::Syck::DefaultKey Syck::DefaultKey
     ]
-    atm = if RUBY_VERSION >= '2.6'
-            YAML.safe_load(YAML.dump(spec),
-                           permitted_classes: permitted_classes)
-          else
-            YAML.safe_load(YAML.dump(spec), permitted_classes)
+    permitted_symbols = %w[development runtime]
+    atm = begin
+            YAML.safe_load(
+              YAML.dump(spec),
+              permitted_classes: permitted_classes,
+              permitted_symbols: permitted_symbols,
+              aliases: true
+            )
+          rescue
+            YAML.safe_load(
+              YAML.dump(spec), permitted_classes, permitted_symbols, true
+            )
           end
     atm.name = 'archive-tar-minitar'
     d = %Q('#{atm.name}' has been deprecated; just install '#{spec.name}'.)

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -134,6 +134,17 @@ class TestTarWriter < Minitest::Test
     end
   end
 
+  def test_add_file_simple_content_with_long_name
+    @dummyos.reset
+
+    long_name_file_content = 'where_is_all_the_content_gone'
+
+    @os.add_file_simple('a' * 114,  mode: 0o0644, data: long_name_file_content)
+
+    assert_equal(long_name_file_content,
+                 @dummyos.data[3 * 512, long_name_file_content.bytesize])
+  end
+
   def test_add_file
     dummyos = StringIO.new
     def dummyos.method_missing(meth, *a) # rubocop:disable Style/MethodMissing

--- a/test/test_tar_writer.rb
+++ b/test/test_tar_writer.rb
@@ -145,6 +145,24 @@ class TestTarWriter < Minitest::Test
                  @dummyos.data[3 * 512, long_name_file_content.bytesize])
   end
 
+  def test_add_file_content_with_long_name
+    dummyos = StringIO.new
+    def dummyos.method_missing(meth, *a) # rubocop:disable Style/MethodMissing
+      string.send(meth, *a)
+    end
+
+    long_name_file_content = 'where_is_all_the_content_gone'
+
+    Minitar::Writer.open(dummyos) do |os|
+      os.add_file('a' * 114,  mode: 0o0644) do |f|
+        f.write(long_name_file_content)
+      end
+    end
+
+    assert_equal(long_name_file_content,
+                 dummyos[3 * 512, long_name_file_content.bytesize])
+  end
+
   def test_add_file
     dummyos = StringIO.new
     def dummyos.method_missing(meth, *a) # rubocop:disable Style/MethodMissing


### PR DESCRIPTION
Hi! Stumbled across this while using Minitar::Writer#add_file. First 1024 bytes of the files content will be overwritten by long file content and original files header without this when using a long file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/minitar/40)
<!-- Reviewable:end -->
