### PR TITLE
Fix the comment of Archive::Tar::Minitar.pack

### DIFF
--- a/lib/archive/tar/minitar.rb
+++ b/lib/archive/tar/minitar.rb
@@ -220,8 +220,8 @@ module Archive::Tar::Minitar
     # the resulting Archive::Tar::Minitar::Output stream; if +recurse_dirs+ is
     # true, then directories will be recursed.
     #
-    # If +src+ is an Array, it will be treated as the result of Find.find; all
-    # files matching will be packed.
+    # If +src+ is not an Array, it will be treated as the result of Find.find;
+    # all files matching will be packed.
     def pack(src, dest, recurse_dirs = true, &block)
       require "find"
       Output.open(dest) do |outp|


### PR DESCRIPTION
`Archive::Tar::Minitar.pack` uses `Find.find` if `src` is **not** an array, but its comment does not seem to be correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/minitar/43)
<!-- Reviewable:end -->
