### PR TITLE
When tarball is created with a long filename with size of 512 or multiples of 512, GNU tar is raising `tar: A lone zero block at `

### DIFF
--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -308,7 +308,7 @@ module Archive::Tar::Minitar
           :prefix => "",
           :name => PosixHeader::GNU_EXT_LONG_LINK,
           :typeflag => "L",
-          :size => long_name.length,
+          :size => long_name.length + 1,
           :mode => 0
         }
         @io.write(PosixHeader.new(long_name_header))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/minitar/47)
<!-- Reviewable:end -->
