### PR TITLE
Properly handle GNUtar long file reading

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,13 +20,12 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
           - head
           - jruby
           - jruby-head
           - truffleruby
           - truffleruby-head
-          - truffleruby+graalvm
-          - truffleruby+graalvm-head
         include:
           - ruby: head
             continue-on-error: true
@@ -55,8 +54,7 @@ jobs:
           - os: ubuntu-22.04
             ruby: '3.2'
           - os: ubuntu-22.04
-            ruby: truffleruby+graalvm-head
-            continue-on-error: true
+            ruby: '3.3'
           - os: ubuntu-22.04
             ruby: truffleruby-head
             continue-on-error: true

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.12 / 2024-08-DD
+
+- Properly handle very long GNU filenames, resolving [#46][].
+
 ## 0.11 / 2022-12-31
 
 - symlink support is complete. Merged as PR [#42][], rebased and built on top of
@@ -190,3 +194,4 @@
 [#40]: https://github.com/halostatue/minitar/pull/40
 [#42]: https://github.com/halostatue/minitar/pull/42
 [#43]: https://github.com/halostatue/minitar/pull/43
+[#46]: https://github.com/halostatue/minitar/issues/46

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,9 +11,7 @@ cli  :: https://github.com/halostatue/minitar-cli
 The minitar library is a pure-Ruby library that provides the ability to deal
 with POSIX tar(1) archive files.
 
-This is release 0.9, adding a minor feature to Minitar.unpack and
-Minitar::Input#extract_entry that when <tt>:fsync => false</tt> is provided,
-fsync will be skipped.
+This is release 0.12. This is likely the last revision before 1.0.
 
 minitar (previously called Archive::Tar::Minitar) is based heavily on code
 originally written by Mauricio Julio Fernández Pradier for the rpa-base

--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,7 @@ expecting this executable, make sure you also install `minitar-cli`.
 
   spec_extras[:metadata] = ->(val) { val["rubygems_mfa_required"] = "true" }
 
+  extra_dev_deps << ["base64", "~> 0.2"]
   extra_dev_deps << ["hoe", "~> 4.0"]
   extra_dev_deps << ["hoe-doofus", "~> 1.0"]
   extra_dev_deps << ["hoe-gemspec2", "~> 1.1"]

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,7 @@ expecting this executable, make sure you also install `minitar-cli`.
   extra_dev_deps << ["hoe-rubygems", "~> 1.0"]
   extra_dev_deps << ["minitest", "~> 5.16"]
   extra_dev_deps << ["minitest-autotest", "~> 1.0"]
+  extra_dev_deps << ["minitest-focus", "~> 1.0"]
   extra_dev_deps << ["rake", ">= 10.0", "< 14"]
   extra_dev_deps << ["rdoc", ">= 0.0"]
   extra_dev_deps << ["standard", "~> 1.0"]

--- a/archive-tar-minitar.gemspec
+++ b/archive-tar-minitar.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: archive-tar-minitar 0.10 ruby lib
+# stub: archive-tar-minitar 0.12 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "archive-tar-minitar".freeze
-  s.version = "0.10"
+  s.version = "0.12".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/minitar/issues", "homepage_uri" => "https://github.com/halostatue/minitar/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/minitar/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2022-12-27"
+  s.date = "2024-08-06"
   s.description = "'archive-tar-minitar' has been deprecated; just install 'minitar'. The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.9, adding a minor feature to Minitar.unpack and\nMinitar::Input#extract_entry that when <tt>:fsync => false</tt> is provided,\nfsync will be skipped.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.files = ["lib/archive-tar-minitar.rb".freeze]
@@ -17,18 +17,11 @@ Gem::Specification.new do |s|
   s.licenses = ["Ruby".freeze, "BSD-2-Clause".freeze]
   s.post_install_message = "'archive-tar-minitar' has been deprecated; just install 'minitar'.".freeze
   s.required_ruby_version = Gem::Requirement.new(">= 1.8".freeze)
-  s.rubygems_version = "3.3.26".freeze
+  s.rubygems_version = "3.5.17".freeze
   s.summary = "'archive-tar-minitar' has been deprecated; just install 'minitar'.".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<minitar>.freeze, ["~> 0.10"])
-    s.add_runtime_dependency(%q<minitar-cli>.freeze, ["~> 0.10"])
-  else
-    s.add_dependency(%q<minitar>.freeze, ["~> 0.10"])
-    s.add_dependency(%q<minitar-cli>.freeze, ["~> 0.10"])
-  end
+  s.add_runtime_dependency(%q<minitar>.freeze, ["~> 0.12".freeze])
+  s.add_runtime_dependency(%q<minitar-cli>.freeze, ["~> 0.12".freeze])
 end

--- a/archive-tar-minitar.gemspec
+++ b/archive-tar-minitar.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
   s.date = "2024-08-06"
-  s.description = "'archive-tar-minitar' has been deprecated; just install 'minitar'. The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.9, adding a minor feature to Minitar.unpack and\nMinitar::Input#extract_entry that when <tt>:fsync => false</tt> is provided,\nfsync will be skipped.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
+  s.description = "'archive-tar-minitar' has been deprecated; just install 'minitar'. The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.12. This is likely the last revision before 1.0.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.files = ["lib/archive-tar-minitar.rb".freeze]
   s.homepage = "https://github.com/halostatue/minitar/".freeze

--- a/lib/archive/tar/minitar.rb
+++ b/lib/archive/tar/minitar.rb
@@ -74,7 +74,7 @@ end
 #       tar.close
 #     end
 module Archive::Tar::Minitar
-  VERSION = "0.11".freeze # :nodoc:
+  VERSION = "0.12".freeze # :nodoc:
 
   # The base class for any minitar error.
   Error = Class.new(::StandardError)

--- a/lib/archive/tar/minitar/posix_header.rb
+++ b/lib/archive/tar/minitar/posix_header.rb
@@ -144,7 +144,7 @@ class Archive::Tar::Minitar::PosixHeader
     v[:version] ||= "00"
 
     FIELDS.each do |f|
-      instance_variable_set("@#{f}", v[f])
+      instance_variable_set(:"@#{f}", v[f])
     end
 
     @empty = v[:empty]

--- a/lib/archive/tar/minitar/reader.rb
+++ b/lib/archive/tar/minitar/reader.rb
@@ -240,8 +240,11 @@ module Archive::Tar::Minitar
         raise Archive::Tar::Minitar::InvalidTarStream if header.size < 0
 
         if header.long_name?
-          name = @io.read(512).rstrip
+          name_block = (header.size / 512.0).ceil * 512
+
+          name = @io.read(name_block).rstrip
           header = PosixHeader.from_stream(@io)
+
           return if header.empty?
           header.name = name
         end

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -340,7 +340,7 @@ module Archive::Tar::Minitar
         name = newname
       end
 
-      [name, prefix, (bytesize(name) > 100 || bytesize(prefix) > 155)]
+      [name, prefix, bytesize(name) > 100 || bytesize(prefix) > 155]
     end
   end
 end

--- a/minitar.gemspec
+++ b/minitar.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
   s.date = "2024-08-06"
-  s.description = "The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.9, adding a minor feature to Minitar.unpack and\nMinitar::Input#extract_entry that when <tt>:fsync => false</tt> is provided,\nfsync will be skipped.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
+  s.description = "The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.12. This is likely the last revision before 1.0.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "docs/bsdl.txt".freeze, "docs/ruby.txt".freeze]
   s.files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "docs/bsdl.txt".freeze, "docs/ruby.txt".freeze, "lib/archive-tar-minitar.rb".freeze, "lib/archive/tar/minitar.rb".freeze, "lib/archive/tar/minitar/input.rb".freeze, "lib/archive/tar/minitar/output.rb".freeze, "lib/archive/tar/minitar/posix_header.rb".freeze, "lib/archive/tar/minitar/reader.rb".freeze, "lib/archive/tar/minitar/writer.rb".freeze, "lib/minitar.rb".freeze, "support/hoe/deprecated_gem.rb".freeze, "test/minitest_helper.rb".freeze, "test/support/tar_test_helpers.rb".freeze, "test/test_tar_header.rb".freeze, "test/test_tar_input.rb".freeze, "test/test_tar_output.rb".freeze, "test/test_tar_reader.rb".freeze, "test/test_tar_writer.rb".freeze]
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.specification_version = 4
 
   s.add_development_dependency(%q<minitest>.freeze, ["~> 5.24".freeze])
+  s.add_development_dependency(%q<base64>.freeze, ["~> 0.2".freeze])
   s.add_development_dependency(%q<hoe>.freeze, ["~> 4.0".freeze])
   s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0".freeze])
   s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1".freeze])

--- a/minitar.gemspec
+++ b/minitar.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: minitar 0.10 ruby lib
+# stub: minitar 0.12 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "minitar".freeze
-  s.version = "0.10"
+  s.version = "0.12".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/minitar/issues", "homepage_uri" => "https://github.com/halostatue/minitar/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/minitar/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2022-12-27"
+  s.date = "2024-08-06"
   s.description = "The minitar library is a pure-Ruby library that provides the ability to deal\nwith POSIX tar(1) archive files.\n\nThis is release 0.9, adding a minor feature to Minitar.unpack and\nMinitar::Input#extract_entry that when <tt>:fsync => false</tt> is provided,\nfsync will be skipped.\n\nminitar (previously called Archive::Tar::Minitar) is based heavily on code\noriginally written by Mauricio Julio Fern\u00E1ndez Pradier for the rpa-base\nproject.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "docs/bsdl.txt".freeze, "docs/ruby.txt".freeze]
@@ -19,36 +19,21 @@ Gem::Specification.new do |s|
   s.post_install_message = "The `minitar` executable is no longer bundled with `minitar`. If you are\nexpecting this executable, make sure you also install `minitar-cli`.\n".freeze
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 1.8".freeze)
-  s.rubygems_version = "3.3.26".freeze
+  s.rubygems_version = "3.5.17".freeze
   s.summary = "The minitar library is a pure-Ruby library that provides the ability to deal with POSIX tar(1) archive files".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_development_dependency(%q<minitest>.freeze, ["~> 5.16"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 4.0"])
-    s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_development_dependency(%q<hoe-git2>.freeze, ["~> 1.7"])
-    s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_development_dependency(%q<rdoc>.freeze, [">= 0.0"])
-    s.add_development_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.21"])
-  else
-    s.add_dependency(%q<minitest>.freeze, ["~> 5.16"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 4.0"])
-    s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<hoe-git2>.freeze, ["~> 1.7"])
-    s.add_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_dependency(%q<rdoc>.freeze, [">= 0.0"])
-    s.add_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<simplecov>.freeze, ["~> 0.21"])
-  end
+  s.add_development_dependency(%q<minitest>.freeze, ["~> 5.24".freeze])
+  s.add_development_dependency(%q<hoe>.freeze, ["~> 4.0".freeze])
+  s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1".freeze])
+  s.add_development_dependency(%q<hoe-git2>.freeze, ["~> 1.7".freeze])
+  s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<rake>.freeze, [">= 10.0".freeze, "< 14".freeze])
+  s.add_development_dependency(%q<rdoc>.freeze, [">= 0.0".freeze])
+  s.add_development_dependency(%q<standard>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.21".freeze])
 end

--- a/support/hoe/deprecated_gem.rb
+++ b/support/hoe/deprecated_gem.rb
@@ -39,7 +39,7 @@ module Hoe::Deprecated_Gem # standard:disable Naming/ClassAndModuleCamelCase
 
     unless @include_all
       [:signing_key, :cert_chain].each { |name|
-        atm.send("#{name}=".to_sym, atm.default_value(name))
+        atm.send(:"#{name}=", atm.default_value(name))
       }
     end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -5,6 +5,7 @@ require "minitar"
 
 gem "minitest"
 require "minitest/autorun"
+require "minitest/focus"
 
 Dir.glob(File.join(File.dirname(__FILE__), "support/*.rb")).sort.each do |support|
   require support

--- a/test/test_issue_46.rb
+++ b/test/test_issue_46.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+require "minitar"
+require "minitest_helper"
+require "base64"
+require "zlib"
+
+class TestIssue46 < Minitest::Test
+  SUPERLONG_TGZ = Base64.decode64(<<-EOS).freeze
+H4sIAK1+smYAA+3WQQ6CMBAF0K49BScAprYd3XkALoECSiQlQYzXt0IkSKLGBdXE
+/zbtNF000PkQRmG0SWq7T0p7FPOIHaNUNzrTkWI5zPt1IiYtgmSm8zw4n9q0CQLR
+1HX7at/lkOeVjwP5FZNcKm14tU63uyyPUP91/e3rCJ75uF/j/Gej+6yXw/fArbnM
+Z2ZlDKlb/ktNrEQQ+3gA9/xP3aS0z/e5bUXh40B+/Vj+oJ63Xkzff26zoqzmzf13
+/d/98437n0izQf8DAAAAAAAAAAAAAAAAAHziCqQuXDYAKAAA
+  EOS
+
+  FILETIMES = Time.utc(2004).to_i
+
+  superlong_name = (["0123456789abcde"] * 33).join("/")
+
+  SUPERLONG_CONTENTS = {
+    superlong_name => {:size => 496, :mode => 0o644},
+    "endfile" => {:size => 0, :mode => 0o644}
+  }
+
+  def test_each_works
+    reader = Zlib::GzipReader.new(StringIO.new(SUPERLONG_TGZ))
+
+    Minitar::Input.open(reader) do |stream|
+      outer = 0
+      stream.each.with_index do |entry, i|
+        assert_kind_of Minitar::Reader::EntryStream, entry
+        assert SUPERLONG_CONTENTS.key?(entry.name), "File #{entry.name} not defined"
+
+        assert_equal SUPERLONG_CONTENTS[entry.name][:size],
+          entry.size,
+          "File sizes sizes do not match: #{entry.name}"
+
+        assert_modes_equal(SUPERLONG_CONTENTS[entry.name][:mode],
+          entry.mode, entry.name)
+        assert_equal(FILETIMES, entry.mtime, "entry.mtime")
+
+        outer += 1
+      end
+
+      assert_equal(2, outer)
+    end
+  end
+end


### PR DESCRIPTION
- **fix: Resolve long filename reader handling**
- **chore: Add minitest-focus for focussed testing**
- **chore: Bump to version 0.12 for release**
- **chore: Fix a missing symbol interpolation**
- **chore: Regenerate gemspecs**
