### PR TITLE
fix: Write very long filenames in GNUtar format correctly

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -83,8 +83,9 @@ Thanks to everyone who has contributed to minitar:
 - Mike Furr
 - ooooooo_q
 - Pete Fritchman
-- Zach Dennis
+- Vijay (bv-vijay)
 - Yamamoto Kōhei
+- Zach Dennis
 
 [minitest]: https://github.com/seattlerb/minitest
 [quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 ## 0.12 / 2024-08-DD
 
 - Properly handle very long GNU filenames, resolving [#46][].
+- Handle very long GNU filenames that are 512 or more bytes, resolving [#45][].
+  Originally implemented in [#47][] by Vijay, but accidentally closed.
 
 ## 0.11 / 2022-12-31
 
@@ -194,4 +196,6 @@
 [#40]: https://github.com/halostatue/minitar/pull/40
 [#42]: https://github.com/halostatue/minitar/pull/42
 [#43]: https://github.com/halostatue/minitar/pull/43
+[#45]: https://github.com/halostatue/minitar/issues/45
 [#46]: https://github.com/halostatue/minitar/issues/46
+[#47]: https://github.com/halostatue/minitar/pull/47

--- a/lib/archive/tar/minitar/writer.rb
+++ b/lib/archive/tar/minitar/writer.rb
@@ -308,7 +308,7 @@ module Archive::Tar::Minitar
           :prefix => "",
           :name => PosixHeader::GNU_EXT_LONG_LINK,
           :typeflag => "L",
-          :size => long_name.length,
+          :size => long_name.length + 1,
           :mode => 0
         }
         @io.write(PosixHeader.new(long_name_header))


### PR DESCRIPTION
Closes: #45
Closes: #47
