### PR TITLE
feat: Support large file size entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## NEXT / 2025-MM-DD
+## 1.1.0 / 2025-09-DD
+
+- Enhancements:
+
+  - Support large file size encoded in base-256 encoding which is a GNU tar
+    extension [#121][pull-121].
+
+  - Support large file size encoded in PAX extension header. [#121][pull-121].
 
 - Governance:
 
-  Changes described here are effective 2024-12-31.
+  Changes described below are effective 2024-12-31.
 
   - Update gem management details to use markdown files for everything, enabled
     in part by [flavorjones/hoe-markdown][hoe-markdown]. Several files were
@@ -16,7 +23,7 @@
 
   Changes described below are effective 2025-08-04.
 
-  - Contributions to minitar-cli now require a DCO certification.
+  - Contributions to minitar now require a DCO certification.
 
 ## 1.0.2 / 2024-08-23
 
@@ -261,4 +268,5 @@
 [pull-42]: https://github.com/halostatue/minitar/pull/42
 [pull-43]: https://github.com/halostatue/minitar/pull/43
 [pull-47]: https://github.com/halostatue/minitar/pull/47
+[pull-121]: https://github.com/halostatue/minitar/pull/121
 [tidelift]: https://tidelift.com/security

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ Thanks to everyone who has contributed to minitar:
 - Mike Furr
 - [@ooooooo-q](https://github.com/ooooooo-q)
 - Pete Fritchman
+- [@sorah](https://github.com/sorah)
 - Vijay ([@bv-vijay](https://github.com/bv-vijay))
 - Yamamoto Kōhei
 - Zach Dennis

--- a/lib/minitar.rb
+++ b/lib/minitar.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 require "rbconfig"
+require "rbconfig/sizeof"
 
 # == Synopsis
 #
@@ -286,6 +287,7 @@ class << Minitar
 end
 
 require "minitar/posix_header"
+require "minitar/pax_header"
 require "minitar/input"
 require "minitar/output"
 require "minitar/version"

--- a/lib/minitar/pax_header.rb
+++ b/lib/minitar/pax_header.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+class Minitar
+  # Implements the PAX Extended Header as a Ruby class. The header consists of following strings:
+  #
+  #    <wordlength><space><asciikeyword>=<asciivalue>\n
+  #
+  # There are several keywords defined in the POSIX standard and some of them are supported in this class.
+  # This class provides minimal functionality to extract size information for large file support.
+  class PaxHeader
+    BLOCK_SIZE = 512
+
+    attr_reader :attributes
+
+    class << self
+      # Creates a new PaxHeader from a data stream and posix header.
+      # Reads the PAX content based on the size specified in the posix header.
+      def from_stream(stream, posix_header)
+        raise ArgumentError, "Header must be a PAX header" unless posix_header.pax_header?
+
+        pax_block = (posix_header.size / BLOCK_SIZE.to_f).ceil * BLOCK_SIZE
+        pax_content = stream.read(pax_block)
+
+        raise Minitar::InvalidTarStream if pax_content.nil? || pax_content.bytesize < posix_header.size
+
+        actual_content = pax_content[0, posix_header.size]
+
+        from_data(actual_content)
+      end
+
+      # Creates a new PaxHeader from PAX content data.
+      def from_data(content)
+        new(parse_content(content))
+      end
+
+      private
+
+      def parse_content(content)
+        attributes = {}
+        offset = 0
+        while offset < content.bytesize
+          space_pos = content.index(' ', offset)
+          break unless space_pos
+
+          length_str = content[offset, space_pos - offset]
+          unless length_str.match?(/\A\d+\z/)
+            raise ArgumentError, "Invalid length format in PAX header: '#{length_str}'"
+          end
+
+          length = length_str.to_i
+          if offset + length > content.bytesize
+            raise ArgumentError, "Length beyond PAX header: '#{content[offset..-1]}'"
+          end
+          record = content[offset, length]
+
+          keyword_value = record[(space_pos - offset + 1)..-2]
+          if keyword_value.include?('=')
+            keyword, value = keyword_value.split('=', 2)
+            attributes[keyword] = value
+          end
+
+          offset += length
+        end
+        attributes
+      end
+    end
+
+    # Creates a new PaxHeader from attributes hash.
+    def initialize(attributes = {})
+      @attributes = attributes.transform_keys(&:to_s)
+    end
+
+    # The size value from PAX attributes
+    def size
+      @attributes['size']&.to_i
+    end
+
+    # The path value from PAX attributes
+    def path
+      @attributes['path']
+    end
+
+    # The mtime value from PAX attributes
+    def mtime
+      @attributes['mtime']&.to_f
+    end
+
+    # Returns a string representation of the PAX header content.
+    def to_s
+      @attributes.map do |keyword, value|
+        keyword_value = " #{keyword}=#{value}\n"
+        record = keyword_value
+        begin
+          length = record.bytesize
+          length_str = length.to_s
+          record = "#{length_str}#{keyword_value}"
+        end while record.size != length
+        record
+      end.join
+    end
+
+  end
+end

--- a/lib/minitar/posix_header.rb
+++ b/lib/minitar/posix_header.rb
@@ -53,10 +53,13 @@ class Minitar
     # longer (up to BLOCK_SIZE bytes) if using the GNU long name tar extension.
     attr_accessor :name
 
+    # The size of the file. Required.
+    attr_accessor :size
+
     # The pack format passed to Array#pack for encoding a header.
     HEADER_PACK_FORMAT = "a100a8a8a8a12a12a7aaa100a6a2a32a32a8a8a155"
     # The unpack format passed to String#unpack for decoding a header.
-    HEADER_UNPACK_FORMAT = "Z100A8A8A8A12A12A8aZ100A6A2Z32Z32A8A8Z155"
+    HEADER_UNPACK_FORMAT = "Z100A8A8A8a12A12A8aZ100A6A2Z32Z32A8A8Z155"
 
     class << self
       # Creates a new PosixHeader from a data stream.
@@ -78,7 +81,7 @@ class Minitar
         mode = fields.shift.oct
         uid = fields.shift.oct
         gid = fields.shift.oct
-        size = strict_oct(fields.shift)
+        size = parse_numeric_field(fields.shift)
         mtime = fields.shift.oct
         checksum = fields.shift.oct
         typeflag = fields.shift
@@ -116,9 +119,25 @@ class Minitar
 
       private
 
-      def strict_oct(string)
-        return string.oct if /\A[0-7 ]*\z/.match?(string)
-        raise ArgumentError, "#{string.inspect} is not a valid octal string"
+      def parse_numeric_field(string)
+        return string.oct if /\A[0-7 \0]*\z/.match?(string) # \0 appears as a padding
+        return parse_base256(string) if string.bytes.first == 0x80 || string.bytes.first == 0xff
+        raise ArgumentError, "#{string.inspect} is not a valid numeric field"
+      end
+
+      def parse_base256(string)
+        # https://www.gnu.org/software/tar/manual/html_node/Extensions.html
+        bytes = string.bytes
+        case bytes.first
+        when 0x80 # Positive number: *non-leading* bytes, number in big-endian order
+          bytes[1..-1].inject(0) { |r, byte| (r << 8) | byte }
+        when 0xff # Negative number: *all* bytes, two's complement in big-endian order
+          result = bytes.inject(0) { |r, byte| (r << 8) | byte }
+          bit_length = bytes.size * 8
+          result - (1 << bit_length)
+        else
+          raise ArgumentError, "Invalid binary field format"
+        end
       end
     end
 
@@ -158,6 +177,12 @@ class Minitar
       typeflag == "L" && name == GNU_EXT_LONG_LINK
     end
 
+    # Returns +true+ if the header is a PAX extended header which contains
+    # metadata for the next file entry.
+    def pax_header?
+      typeflag == "x"
+    end
+
     # A string representation of the header.
     def to_s
       update_checksum
@@ -192,10 +217,6 @@ class Minitar
       str = arr.pack(HEADER_PACK_FORMAT)
       str + "\0" * ((BLOCK_SIZE - str.bytesize) % BLOCK_SIZE)
     end
-
-    ##
-    # :attr_reader: size
-    # The size of the file. Required.
 
     ##
     # :attr_reader: prefix

--- a/lib/minitar/reader.rb
+++ b/lib/minitar/reader.rb
@@ -244,6 +244,15 @@ class Minitar
 
           return if header.empty?
           header.name = name
+        elsif header.pax_header?
+          pax_header = PaxHeader.from_stream(@io, header)
+
+          header = PosixHeader.from_stream(@io)
+          return if header.empty?
+
+          if pax_header.size
+            header.size = pax_header.size
+          end
         end
 
         entry = EntryStream.new(header, @io)
@@ -255,7 +264,7 @@ class Minitar
 
         if Minitar.seekable?(@io, :seek)
           # avoid reading...
-          @io.seek(size - entry.bytes_read, IO::SEEK_CUR)
+          try_seek(size - entry.bytes_read)
         else
           pending = size - entry.bytes_read
           while pending > 0
@@ -278,6 +287,23 @@ class Minitar
     end
 
     def close
+    end
+
+    private
+
+    def try_seek(bytes)
+      raise RangeError
+      @io.seek(bytes, IO::SEEK_CUR)
+    rescue RangeError
+      # This happens when skipping the large entry and the skipping entry size exceeds
+      # maximum allowed size (varies by platform and underlying IO object).
+      max = RbConfig::LIMITS.fetch('INT_MAX', 2147483647)
+      skipped = 0
+      while skipped < bytes
+        to_skip = [bytes - skipped, max].min
+        @io.seek(to_skip, IO::SEEK_CUR)
+        skipped += to_skip
+      end
     end
   end
 end

--- a/test/support/tar_test_helpers.rb
+++ b/test/support/tar_test_helpers.rb
@@ -76,6 +76,10 @@ module TarTestHelpers
     update_checksum(header("2", name, prefix, 0, mode, target))
   end
 
+  def tar_pax_header(name, prefix, content_size)
+    update_checksum(header("x", name, prefix, content_size, 0o644))
+  end
+
   def header(type, fname, dname, length, mode, link_name = "")
     raw_header(type,
       asciiz(fname, 100),

--- a/test/test_pax_header.rb
+++ b/test/test_pax_header.rb
@@ -1,0 +1,104 @@
+require "minitest_helper"
+
+class TestPaxHeader < Minitest::Test
+  def test_from_stream_with_size_attribute
+    pax_content = "19 size=8614356715\n28 mtime=1749098832.3200000\n"
+    pax_header = create_pax_header_from_stream(pax_content)
+
+    assert_equal 8614356715, pax_header.size
+    assert_equal "1749098832.3200000", pax_header.attributes["mtime"]
+  end
+
+  def test_from_stream_without_size_attribute
+    pax_content = "28 mtime=1749098832.3200000\n27 path=some/long/path.txt\n"
+    pax_header = create_pax_header_from_stream(pax_content)
+
+    assert_nil pax_header.size
+    assert_equal "some/long/path.txt", pax_header.path
+    assert_equal 1749098832.32, pax_header.mtime
+  end
+
+  def test_parse_multiline_values
+    pax_content = "22 foo=one\ntwo\nthree\n\n12 bar=four\n"
+    pax_header = Minitar::PaxHeader.from_data(pax_content)
+    assert_equal "one\ntwo\nthree\n", pax_header.attributes["foo"]
+    assert_equal "four", pax_header.attributes["bar"]
+  end
+
+  def test_from_stream_with_invalid_header
+    header_data = tar_file_header("regular_file.txt", "", 0o644, 100)
+    io = StringIO.new(header_data)
+
+    posix_header = Minitar::PosixHeader.from_stream(io)
+    refute posix_header.pax_header?
+
+    assert_raises(ArgumentError, "Header must be a PAX header") do
+      Minitar::PaxHeader.from_stream(io, posix_header)
+    end
+  end
+
+  def test_parse_content_with_multiple_attributes
+    pax_content = "19 size=8614356715\n28 mtime=1749098832.3200000\n27 path=some/long/path.txt\n"
+
+    pax_header = Minitar::PaxHeader.from_data(pax_content)
+
+    assert_equal 8614356715, pax_header.size
+    assert_equal "some/long/path.txt", pax_header.path
+    assert_equal 1749098832.32, pax_header.mtime
+
+    # Check raw attributes
+    assert_equal "8614356715", pax_header.attributes["size"]
+    assert_equal "1749098832.3200000", pax_header.attributes["mtime"]
+    assert_equal "some/long/path.txt", pax_header.attributes["path"]
+  end
+
+  def test_parse_content_with_invalid_length_format
+    assert_raises(ArgumentError) do
+      Minitar::PaxHeader.from_data("19 size=8614356715\ninvalid line\n23 path=valid/path.txt\n")
+    end
+  end
+
+  def test_parse_content_with_oversized_record
+    assert_raises(ArgumentError) do
+      Minitar::PaxHeader.from_data("19 size=8614356715\n999 toolong=value\n")
+    end
+  end
+
+  def test_from_stream_strips_padding
+    pax_content = "19 size=8614356715\n"
+    pax_header = create_pax_header_from_stream(pax_content)
+
+    # Should parse only the actual content, ignoring padding
+    assert_equal 8614356715, pax_header.size
+    assert_equal 1, pax_header.attributes.size  # Only one attribute parsed
+
+    # Should have parsed content correctly
+    assert_equal 1, pax_header.attributes.size
+    assert_equal "8614356715", pax_header.attributes["size"]
+  end
+
+  def test_attributes_accessor
+    pax_content = "19 size=8614356715\n23 custom=custom_value\n"
+    pax_header = Minitar::PaxHeader.from_data(pax_content)
+
+    assert_equal "8614356715", pax_header.attributes["size"]
+    assert_equal "custom_value", pax_header.attributes["custom"]
+    assert_nil pax_header.attributes["nonexistent"]
+  end
+
+  def test_pax_header_to_s
+    pax_header = Minitar::PaxHeader.new(size: "8614356715", mtime: "1749098832.3200000")
+    assert_equal "19 size=8614356715\n28 mtime=1749098832.3200000\n", pax_header.to_s
+  end
+
+  private
+
+  def create_pax_header_from_stream(pax_content, name = "./PaxHeaders.X/test_file")
+    pax_header_data = tar_pax_header(name, "", pax_content.bytesize)
+    padded_content = pax_content.ljust(((pax_content.bytesize / 512.0).ceil * 512), "\0")
+    io = StringIO.new(pax_header_data + padded_content)
+
+    posix_header = Minitar::PosixHeader.from_stream(io)
+    Minitar::PaxHeader.from_stream(io, posix_header)
+  end
+end

--- a/test/test_pax_support.rb
+++ b/test/test_pax_support.rb
@@ -1,0 +1,66 @@
+require "minitest_helper"
+
+class TestPaxSupport < Minitest::Test
+  def test_pax_header_size_extraction_in_reader
+    pax_content = "16 size=1048576\n28 mtime=1749098832.3200000\n"
+    tar_data = create_pax_with_file_headers(pax_content, "./PaxHeaders.X/large_file.mov", "large_file.mov", 1048576, 0)
+
+    entries = read_tar_entries(tar_data)
+    assert_equal 1, entries.size
+
+    entry = entries.first
+    assert_equal "large_file.mov", entry.name
+    assert_equal 1048576, entry.size  # Size from PAX header
+  end
+
+  def test_pax_header_without_size_uses_header_size
+    pax_content = "28 mtime=1749098832.3200000\n"
+    tar_data = create_pax_with_file_headers(pax_content, "./PaxHeaders.X/normal_file.txt", "normal_file.txt", 12345, 12345)
+
+    entries = read_tar_entries(tar_data)
+    assert_equal 1, entries.size
+
+    entry = entries.first
+    assert_equal "normal_file.txt", entry.name
+    assert_equal 12345, entry.size  # Original header size preserved
+  end
+
+  def test_pax_header_takes_precedence_over_posix_header_size
+    pax_content = "16 size=1048576\n28 mtime=1749098832.3200000\n"
+    tar_data = create_pax_with_file_headers(pax_content, "./PaxHeaders.X/precedence_file.txt", "precedence_file.txt", 12345, 12345)
+
+    entries = read_tar_entries(tar_data)
+    assert_equal 1, entries.size
+
+    entry = entries.first
+    assert_equal "precedence_file.txt", entry.name
+    assert_equal 1048576, entry.size  # PAX size takes precedence over POSIX size (12345)
+  end
+
+  def test_pax_size_extraction_logic
+    pax_header_with_size = Minitar::PaxHeader.new(size: "1048576", mtime: "1749098832.3200000")
+    assert_equal 1048576, pax_header_with_size.size
+
+    pax_header_without_size = Minitar::PaxHeader.new(mtime: "1749098832.3200000")
+    assert_nil pax_header_without_size.size
+  end
+
+  private
+
+  def read_tar_entries(tar_data)
+    io = StringIO.new(tar_data)
+    Minitar::Reader.open(io, &:to_a)
+  end
+
+  def create_pax_with_file_headers(pax_content, pax_name, file_name, file_size, posix_header_file_size)
+    file_content = "x" * file_size
+    padded_file_content = file_content.ljust(((file_size / 512.0).ceil * 512), "\0")
+    
+    [
+      tar_pax_header(pax_name, "", pax_content.bytesize),
+      pax_content.ljust(((pax_content.bytesize / 512.0).ceil * 512), "\0"),
+      tar_file_header(file_name, "", 0o644, file_size),
+      padded_file_content
+    ].join
+  end
+end


### PR DESCRIPTION
This is a continuation of #121.

This adds support for two extensions on size, which unlocks the limit of 8GB on traditional file entry header. This improves interoperability for very large tarballs.

- base-256 encoded size: https://www.gnu.org/software/tar/manual/html_node/Extensions.html

- PaxHeader size attribute: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/pax.html#tagfcjh_1

As traditional octal encoding has a limit of approx 8GB, when a tarball contains a entry where its content larger than 8GB, minitar fails to read any following entries due to size mismatch (which causes stream misalignment).

base-256 encoded size appears in GNU tar created tarballs (normal `tar cf ... ...`), and @sorah confirmed PaxHeader appears in Google Takeout tarballs.

Closes: #121
